### PR TITLE
feat : update  finebi version 5.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,17 @@ ADD install_FineBI5_1-CN-expect.sh ./
 
 RUN apt-get update \
  && apt-get install curl expect -y \
- && curl -O https://fine-build.oss-cn-shanghai.aliyuncs.com/finebi/5.1/public/exe/spider/linux_unix_FineBI5_1-CN.sh \
+ && curl -O https://fine-build.oss-cn-shanghai.aliyuncs.com/finebi/5.1.3/stable/exe/spider/linux_unix_FineBI5_1-CN.sh \
+ && chmod 777 install_FineBI5_1-CN-expect.sh linux_unix_FineBI5_1-CN.sh \
  && /install_FineBI5_1-CN-expect.sh \
+ && sed -i 's#nohup# #g' /usr/local/FineBI5.1/bin/finebi \
+ && sed -i 's#> /dev/null 2>&1 &# #g' /usr/local/FineBI5.1/bin/finebi \
  && rm -rf /linux_unix_FineBI5_1-CN.sh \
  && rm -rf /install_FineBI5_1-CN-expect.sh
 
 EXPOSE 37799
-CMD sh -c "nohup /usr/local/FineBI5.1/bin/finebi"
+
+VOLUME [ "/usr/local/FineBI5.1/webapps/webroot" ]
+
+
+CMD ["/usr/local/FineBI5.1/bin/finebi"]

--- a/install_FineBI5_1-CN-expect.sh
+++ b/install_FineBI5_1-CN-expect.sh
@@ -18,6 +18,8 @@ expect "是否创建快捷连接"
 send "n\r"
 expect "添加桌面快捷方式"
 send "n\r"
+expect "生成安全密钥"
+send "n\r"
 expect "运行 FineBI?"
 send "y\r"
 interact


### PR DESCRIPTION
更新finebi到最新版本 5.1.3

去掉`usr/local/FineBI5.1/bin/finebi`中的`nohup`和 `> /dev/null 2>&1 &`，让进程在前台运行，避免docker运行起来就结束。

挂载 `/usr/local/FineBI5.1/webapps/webroot`